### PR TITLE
Added yaml syntax to frontmatter

### DIFF
--- a/assets/syntaxes/njk.json
+++ b/assets/syntaxes/njk.json
@@ -9,6 +9,7 @@
   "foldingStartMarker": "({%\\s*(block|filter|for|if|macro|raw))",
   "foldingStopMarker": "({%\\s*(endblock|endfilter|endfor|endif|endmacro|endraw)\\s*%})",
   "patterns": [
+    {"include": "#frontMatter"},
     {
       "begin": "({%)\\s*(raw)\\s*(%})",
       "captures": {
@@ -77,6 +78,14 @@
     }
   ],
   "repository": {
+    "frontMatter": {
+      "begin": "\\A-{3}\\s*$",
+      "contentName": "meta.embedded.block.frontmatter",
+      "patterns": [{
+        "include": "source.yaml"
+      }],
+    "end": "(^|\\G)-{3}|\\.{3}\\s*$"
+    },
     "escaped_char": {
       "match": "\\\\x[0-9A-F]{2}",
       "name": "constant.character.escape.hex.njk"


### PR DESCRIPTION
fixes #16 
logic taken from the official md syntax rules
https://github.com/microsoft/vscode-markdown-tm-grammar/blob/master/markdown.tmLanguage.base.yaml