### PR TITLE
added .html grammar support

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,16 @@
         "language": "njk",
         "scopeName": "text.html.njk",
         "path": "./assets/syntaxes/njk-html.json"
+      },
+      {
+        "language": "html",
+        "scopeName": "source.njk",
+        "path": "./assets/syntaxes/njk.json"
+      },
+      {
+        "language": "html",
+        "scopeName": "text.html.njk",
+        "path": "./assets/syntaxes/njk-html.json"
       }
     ]
   },


### PR DESCRIPTION
I've added grammar support for **.html** files since **.njk** files are getting in conflict with some plugins like:

- CSS Peek: Go to definition not working
- Prettier: Cannot format Nunjucks files

The only difference in this pull request is that whoever wants to work in **.html** files to avoid conflicts with some plugins, now has the choice.
I just couldn't get snippets to work on the **.html** files and it would be nice to have them.